### PR TITLE
Fix common controls include typo

### DIFF
--- a/ListViewManager.cpp
+++ b/ListViewManager.cpp
@@ -3,7 +3,7 @@
 #include <shlguid.h>
 #include <sstream>
 #include <Shobjidl.h>    // For IImageList
-#include <CommonControls.h>
+#include <commctrl.h>
 #pragma comment(lib, "Shell32.lib")
 #pragma comment(lib, "Comctl32.lib")
 #include <gdiplus.h>

--- a/WindowsProject1.cpp
+++ b/WindowsProject1.cpp
@@ -6,12 +6,11 @@
 #include "framework.h"
 #include "WindowsProject1.h"
 #include "ListedRunnerPlugin.h"
-#include <commctrl.h>
 #include <vector>
 #include <string>
 #include <shlguid.h>
 #include <objbase.h>
-#include <commoncontrols.h>
+#include <commctrl.h>
 #include <shlobj.h>
 #include <sstream>
 #include "ListViewManager.h"


### PR DESCRIPTION
## Summary
- update includes in `ListViewManager.cpp` and `WindowsProject1.cpp`
- drop duplicate include in `WindowsProject1.cpp`

## Testing
- `cmake . -B build` *(fails: CMake 3.31 or higher is required)*
- `g++ -c WindowsProject1.cpp` *(fails: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683fb66e4440832191440924ad936b21