### PR TITLE
feat: support window opacity skin setting

### DIFF
--- a/WindowsProject1.cpp
+++ b/WindowsProject1.cpp
@@ -329,12 +329,17 @@ static void refreshSkin()
 		return;
 	}
 	// --- 1. 更新主窗口 ---
-	int windowWidth = g_skinJson.value("window_width", MAIN_WINDOW_WIDTH);
-	int windowHeight = g_skinJson.value("window_height", MAIN_WINDOW_HEIGHT);
-	SetWindowPos(hWnd, nullptr, 0, 0, windowWidth, windowHeight, SWP_NOMOVE | SWP_NOZORDER);
+        int windowWidth = g_skinJson.value("window_width", MAIN_WINDOW_WIDTH);
+        int windowHeight = g_skinJson.value("window_height", MAIN_WINDOW_HEIGHT);
+        SetWindowPos(hWnd, nullptr, 0, 0, windowWidth, windowHeight, SWP_NOMOVE | SWP_NOZORDER);
 
-	// 处理背景图片
-	getSkinPictureFile(g_BgImage, "window_bg_picture");
+        int windowOpacity = g_skinJson.value("window_opacity", 255);
+        if (windowOpacity < 0) windowOpacity = 0;
+        if (windowOpacity > 255) windowOpacity = 255;
+        SetLayeredWindowAttributes(hWnd, 0, static_cast<BYTE>(windowOpacity), LWA_ALPHA);
+
+        // 处理背景图片
+        getSkinPictureFile(g_BgImage, "window_bg_picture");
 	getSkinPictureFile(g_editBgImage, "editbox_bg_picture");
 	getSkinPictureFile(g_listViewBgImage, "listview_bg_picture");
 	getSkinPictureFile(g_listItemBgImage, "item_font_bg_picture");

--- a/skin_test.json
+++ b/skin_test.json
@@ -2,8 +2,9 @@
 	"version":1,
 	"window_width":500,
 	"window_height":500,
-	"window_bg_picture":"E:\\Github\\airplay\\iot-channel-app\\app\\channel-tv\\src\\main\\res\\drawable-hdpi\\plugin_bindcode_background.png",
-	"window_bg_color":"#888888",
+        "window_bg_picture":"E:\\Github\\airplay\\iot-channel-app\\app\\channel-tv\\src\\main\\res\\drawable-hdpi\\plugin_bindcode_background.png",
+        "window_bg_color":"#888888",
+        "window_opacity":255,
 
 	"editbox_width":437,
 	"editbox_height":50,


### PR DESCRIPTION
## Summary
- allow skins to define overall window opacity
- apply window opacity in refreshSkin
- document new setting in sample skin

## Testing
- `cmake -S . -B build` *(fails: CMake Error at CMakeLists.txt:111 (add_subdirectory): The source directory /workspace/CandyLauncher/3rdparty/RapidFuzz does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_688b30fa68908321a5e85fffa49a15e1